### PR TITLE
Added support for keyword keys

### DIFF
--- a/Lightroom/streamdeck.lrplugin/start.lua
+++ b/Lightroom/streamdeck.lrplugin/start.lua
@@ -219,7 +219,7 @@ local function makeReceiverSocket( context )
 						local key, value = parseMessage( message )
 						if key and value then
 							if setValue( key, value ) then
-								L:trace( string.format( "%s %s!!!", tostring( key ), tostring( value ) ), 4 )
+								-- LrDialogs.showBezel( string.format( "%s %s!!!", tostring( key ), tostring( value ) ), 4 )
 							else
 								LrDialogs.showBezel("Unknown command: \""..message.."\"", 1 )
 							end

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The Lightroom plugin accepts the following zoom messages:
 * Zoom8:1
 * Zoom11:1
 
-...and the following edit parameters:
+...the following edit parameters:
 * Temperature
 * Tint
 * Exposure
@@ -54,11 +54,20 @@ The Lightroom plugin accepts the following zoom messages:
 * Clarity
 * Vibrance
 * Saturation
+* keyword
+* label
+
 
 ...using the syntax `<parameter> = [ + | - | float_value ]`\
 E.g.:\
 `Exposure = +`\
 `Highlights = -0.5`
+
+...and the following library parameters:
+* `keyword = <keyword>`
+* `select = [ next | previous ]`
+* `rating = [ 1 to 5 ]`
+* `flag = [ 1 | 0 | -1 ]`
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The Lightroom plugin accepts the following zoom messages:
 * label
 
 
+
 ...using the syntax `<parameter> = [ + | - | float_value ]`\
 E.g.:\
 `Exposure = +`\


### PR DESCRIPTION
* The streamdeck syntax is `keyword = <keyword>` 
* edited the readme to show the keyword option and also show the options already in code `select`,`flag`,`rating`